### PR TITLE
Keyguard: Don't circular reveal a non-visible view

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardAffordanceView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardAffordanceView.java
@@ -283,7 +283,7 @@ public class KeyguardAffordanceView extends ImageView implements Palette.Palette
         });
         animatorToRadius.start();
         setImageAlpha(0, true);
-        if (mPreviewView != null) {
+        if (mPreviewView != null && mPreviewView.getVisibility() == View.VISIBLE) {
             mPreviewView.setVisibility(View.VISIBLE);
             mPreviewClipper = ViewAnimationUtils.createCircularReveal(
                     mPreviewView, getLeft() + mCenterX, getTop() + mCenterY, mCircleRadius,


### PR DESCRIPTION
This follows the same logic used in the setCirculeRadius method in
this class and avoids performing a circular reveal on a non-visible,
and possibly detached, view.

Change-Id: I238a81433fd78e41192ca099bd68404ae1d0ac6e
TICKET: FEIJ-1501